### PR TITLE
Matching Kernels 1-3

### DIFF
--- a/screenfo
+++ b/screenfo
@@ -246,7 +246,8 @@ if($DEBUG) {
 sub get_kernel {
   open(my $fh, '<', '/proc/version') or warn($!);
   my $version = <$fh>;
-  my ($kernel) = $version =~ /(2\.[0-9]\.[0-9\S]+)/; # works until Linux 3
+  # extended to macht kernels [1-3]
+  my ($kernel) = $version =~ /([1-3]\.[0-9]\.[0-9\S]+)/;
   return($kernel);
 }
 


### PR DESCRIPTION
Since I'm checking out the 3.0.0-rc, I updated the regex to grab the kernel version. While I'm at it, I also included matching for pre-2 kernels, hopefully nobody has a need for that anymore, though :P
