### PR TITLE
Add wm ion3

### DIFF
--- a/screenfo
+++ b/screenfo
@@ -538,6 +538,7 @@ sub get_wm {
     ksmserver        => 'KDE', 
     'gnome-session'  => 'GNOME', 
     sawfish          => 'Sawfish',
+    ion3             => 'Ion3',
 
     # NOTE Not sure of their processes
     'xmonad'      => 'Xmonad', # uses .<arch> prefixes ?


### PR DESCRIPTION
Adds ion3 to the list of known window managers.

If you choose not to merge ticket #4, merge from add_wm_ion3_alt instead.
