### PR TITLE
gnome-session changed to gnome-session-b

### DIFF
--- a/screenfo
+++ b/screenfo
@@ -633,7 +633,7 @@ sub get_wm {
     WMFS             => 'WMFS',
     'xfce4-session'  => 'Xfce',
     ksmserver        => 'KDE',
-    'gnome-session'  => 'GNOME',
+    'gnome-session-b'  => 'GNOME',
     sawfish          => 'Sawfish',
     ion3             => 'Ion3',
     notion           => 'Notion',


### PR DESCRIPTION
I don't know if it's on every system the case but on my arch gnome-session has had a name change to gnome-session-b for whatever reason. might be usefull